### PR TITLE
Require balance of sender of tokens to be greater than or equal to value being sent.

### DIFF
--- a/contracts/modules/token/BaseCheckpoint.sol
+++ b/contracts/modules/token/BaseCheckpoint.sol
@@ -70,7 +70,7 @@ contract CheckpointModule is STModuleBase {
 		onlyOwner
 		returns (bool)
 	{
-		require(balance[_addr[1]] >= _value);
+		require(token.balanceOf(_addr[1]) >= _value);
 		_;
 		if (now < time) return true;
 		if (_rating[0] == 0 && _id[0] != ownerID) {

--- a/contracts/modules/token/BaseCheckpoint.sol
+++ b/contracts/modules/token/BaseCheckpoint.sol
@@ -70,6 +70,8 @@ contract CheckpointModule is STModuleBase {
 		onlyOwner
 		returns (bool)
 	{
+		require(balance[_addr[1]] >= _value);
+		_;
 		if (now < time) return true;
 		if (_rating[0] == 0 && _id[0] != ownerID) {
 			_checkCustodianSent(MiniCustodian(_addr[0]), _id[1], _value);


### PR DESCRIPTION
If the token balance of the sender account is less than the value being sent an exception will be thrown.